### PR TITLE
Adding prometheus instrumentator for fastapi app

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,10 @@
 from fastapi import FastAPI
 
 from app.db import database, User
-
+from prometheus_fastapi_instrumentator import Instrumentator
 
 app = FastAPI(title="FastAPI, Docker, and Traefik")
+instrumentator = Instrumentator().instrument(app)
 
 
 @app.get("/")
@@ -13,6 +14,9 @@ async def read_root():
 
 @app.on_event("startup")
 async def startup():
+    # Expose prometheus metrics using the Instrumentator
+    # https://github.com/trallnag/prometheus-fastapi-instrumentator
+    instrumentator.expose(app)
     if not database.is_connected:
         await database.connect()
     # create a dummy entry

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,6 +1,6 @@
-asyncpg
-fastapi
-ormar
-psycopg2-binary
-uvicorn
-prometheus-fastapi-instrumentator
+asyncpg==0.29.0
+fastapi==0.106.0
+ormar==0.12.2
+psycopg2-binary==2.9.9
+uvicorn==0.25.0
+prometheus-fastapi-instrumentator==6.1.0

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,10 +1,6 @@
-#asyncpg==0.27.0
-#fastapi==0.89.1
-#ormar==0.12.1
-#psycopg2-binary==2.9.5
-#uvicorn==0.20.0
 asyncpg
 fastapi
 ormar
 psycopg2-binary
 uvicorn
+prometheus-fastapi-instrumentator


### PR DESCRIPTION
Installing the Prometheus FastAPI Instrumentator.
https://github.com/trallnag/prometheus-fastapi-instrumentator
And a bit of cleanup.