### PR TITLE
Adding prod terraform definitions

### DIFF
--- a/helm/fastapi-app/values-prod.yaml
+++ b/helm/fastapi-app/values-prod.yaml
@@ -1,0 +1,25 @@
+# Namespace
+namespace: "prod"
+
+ingress:
+  name: "ingress"
+  fastapiHostname: "devops-fastapi-prod.kvark.fr"
+
+# FastAPI app variables
+fastapiApp:
+  replicas: 3
+  name: "fastapi-app"
+  image: "public.ecr.aws/v4m5s6o6/devops-boot:latest"
+  containerPort: 8000
+
+fastapiService:
+  name: "fastapi-service"
+
+fastapiHpa:
+  name: "fastapi-hpa"
+  minReplicas: 5
+  maxReplicas: 10
+  averageUtilization: 70
+
+clusterIssuer:
+  name: "cluster-issuer"

--- a/helm/postgres-cluster/values-prod.yaml
+++ b/helm/postgres-cluster/values-prod.yaml
@@ -1,0 +1,2 @@
+# Namespace
+namespace: "prod"

--- a/terraform/deployments/prod/main.tf
+++ b/terraform/deployments/prod/main.tf
@@ -1,0 +1,33 @@
+resource "kubernetes_namespace" "prod" {
+  metadata {
+    name = "prod"
+  }
+}
+
+module "storageclass" {
+  # Setting up dynamic storageClass
+  source = "../modules/storageclass"
+}
+
+module "releases" {
+  # Helm deployments that are independent of the enviroment
+  source                          = "../releases"
+  s3_backup_aws_access_key_id     = var.s3_backup_aws_access_key_id
+  s3_backup_aws_secret_access_key = var.s3_backup_aws_secret_access_key
+  grafana_admin_password          = var.grafana_admin_password
+}
+
+module "environment_specific_releases" {
+  # Helm deployments that are dependent of the enviroment
+  source          = "./releases"
+  cert_manager_id = module.releases.cert_manager_id
+  depends_on      = [module.releases]
+}
+
+data "aws_eks_cluster" "default" {
+  name = var.cluster_name
+}
+
+data "aws_eks_cluster_auth" "default" {
+  name = var.cluster_name
+}

--- a/terraform/deployments/prod/providers.tf
+++ b/terraform/deployments/prod/providers.tf
@@ -1,0 +1,17 @@
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.default.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.default.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.default.token
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = data.aws_eks_cluster.default.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.default.certificate_authority.0.data)
+    token                  = data.aws_eks_cluster_auth.default.token
+  }
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/terraform/deployments/prod/releases/fastapi_app.tf
+++ b/terraform/deployments/prod/releases/fastapi_app.tf
@@ -1,0 +1,10 @@
+resource "helm_release" "fastapi_app" {
+  name             = "fastapi-app"
+  chart            = "${path.module}/../../../../helm/fastapi-app"
+  create_namespace = true
+  values = [
+    file("${path.module}/../../../../helm/fastapi-app/values-prod.yaml")
+  ]
+  description = var.cert_manager_id # Used for dependency on cert_manager
+  depends_on  = [helm_release.postgres_cluster]
+}

--- a/terraform/deployments/prod/releases/postgres_cluster.tf
+++ b/terraform/deployments/prod/releases/postgres_cluster.tf
@@ -1,0 +1,8 @@
+resource "helm_release" "postgres_cluster" {
+  name             = "postgres-cluster"
+  chart            = "${path.module}/../../../../helm/postgres-cluster"
+  create_namespace = true
+  values = [
+    file("${path.module}/../../../../helm/postgres-cluster/values-prod.yaml")
+  ]
+}

--- a/terraform/deployments/prod/releases/variables.tf
+++ b/terraform/deployments/prod/releases/variables.tf
@@ -1,0 +1,4 @@
+variable "cert_manager_id" {
+  description = "The ID of the Cert manager installation, used for setting dependency"
+  type        = string
+}

--- a/terraform/deployments/prod/terraform.tf
+++ b/terraform/deployments/prod/terraform.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.28"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.24"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12"
+    }
+  }
+  required_version = "~> 1.6"
+}

--- a/terraform/deployments/prod/variables.tf
+++ b/terraform/deployments/prod/variables.tf
@@ -1,0 +1,29 @@
+variable "cluster_name" {
+  description = "Cluster name"
+  type        = string
+  default     = "devops-boot-prod"
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "eu-west-3"
+}
+
+variable "s3_backup_aws_access_key_id" {
+  description = "AWS access key ID for the S3 bucket"
+  type        = string
+  sensitive   = true
+}
+
+variable "s3_backup_aws_secret_access_key" {
+  description = "AWS secret access key for the S3 bucket"
+  type        = string
+  sensitive   = true
+}
+
+variable "grafana_admin_password" {
+  description = "Password for the admin user of Grafana"
+  type        = string
+  sensitive   = true
+}

--- a/terraform/provisioning/prod/main.tf
+++ b/terraform/provisioning/prod/main.tf
@@ -1,0 +1,31 @@
+module "eks" {
+  source = "../modules/eks"
+
+  cluster_name = var.cluster_name
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+
+  eks_managed_node_groups = {
+    node_group_1 = {
+      name = "node-group-1"
+
+      instance_types = ["t3.small"]
+
+      min_size     = 4
+      max_size     = 6
+      desired_size = 5
+    }
+  }
+}
+
+module "vpc" {
+  source = "../modules/network"
+
+  cluster_name = var.cluster_name
+  azs          = module.eks.azs
+
+  cidr            = "10.1.0.0/16"
+  private_subnets = ["10.1.1.0/24", "10.1.2.0/24", "10.1.3.0/24"]
+  public_subnets  = ["10.1.4.0/24", "10.1.5.0/24", "10.1.6.0/24"]
+}

--- a/terraform/provisioning/prod/providers.tf
+++ b/terraform/provisioning/prod/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.region
+}

--- a/terraform/provisioning/prod/terraform.tf
+++ b/terraform/provisioning/prod/terraform.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.28"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.24"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12"
+    }
+  }
+  required_version = "~> 1.6"
+}

--- a/terraform/provisioning/prod/variables.tf
+++ b/terraform/provisioning/prod/variables.tf
@@ -1,0 +1,11 @@
+variable "cluster_name" {
+  description = "Cluster name"
+  type        = string
+  default     = "devops-boot-prod"
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "eu-west-3"
+}


### PR DESCRIPTION
Creating terraform files for the prod environment.
These are copies from the preprod directories, minimally modified (eg. namespace, domain name, autoscaling settings, etc.).

Terraform Cloud and Github Actions have already been set up following the guidelines:
https://developer.hashicorp.com/terraform/tutorials/automation/github-actions