### PR TITLE
Enabling one NAT GW per AZ

### DIFF
--- a/terraform/provisioning/modules/network/main.tf
+++ b/terraform/provisioning/modules/network/main.tf
@@ -10,9 +10,10 @@ module "vpc" {
   private_subnets = var.private_subnets
   public_subnets  = var.public_subnets
 
-  enable_nat_gateway   = true
-  single_nat_gateway   = true
-  enable_dns_hostnames = true
+  enable_nat_gateway     = true
+  single_nat_gateway     = false
+  one_nat_gateway_per_az = true
+  enable_dns_hostnames   = true
 
   public_subnet_tags = {
     "kubernetes.io/cluster/${var.cluster_name}" = "shared"


### PR DESCRIPTION
Moving to one NAT GW per AZ instead of one per region.
https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest#nat-gateway-scenarios